### PR TITLE
Update sponsors and links for team 3707

### DIFF
--- a/_frc/3700/3707.md
+++ b/_frc/3700/3707.md
@@ -7,26 +7,27 @@ team:
   rookie_year: 2011
   location: Brighton, Michigan, USA
   sponsors:
+  - Eberspächer
   - General Motors
-  - Special T's Packaging
-  - Ford
-  - Hitachi
-  - Ilmor Engineering
   - Brighton Area Schools
+  - Brighton Light House
+  - Promess
+  - Altair
+  - Ilmor Engineering
   - State of Michigan
-  - Lingenfelter
-  - Niswander Environmental
+  - Hitachi
   - Conely Auto
-  - TRW
-  - Trescal
-  - DEWESoft
-  - IHA Brighton Family Care
-  - M-1 Studios
-  - Conely Auto
-  - Pet Supplies Plus
+  - FCA
   - Brighton High School
   links:
     Website: http://www.technodogs.org
+    Facebook: https://www.facebook.com/BHStechnodogs
+    Instagram: https://www.instagram.com/technodogs
+    Wiki: http://wiki.technodogs.org
+    GitHub: https://github.com/technodogs
+robot_code:
+  2019:
+  - Robot:
+    - https://github.com/technodogs/Creedence
+    - Java
 ---
-
-{% include remove_this_line_and_add_a_paragraph %}


### PR DESCRIPTION
Updated sponsors with the current information on the [team website](https://www.technodogs.org/sponsors.html) and the [FRC Event Web](https://frc-events.firstinspires.org/2021/team/3707). Also added links to social media and code.